### PR TITLE
feat: Add `Bytes` marker

### DIFF
--- a/src/marker.zig
+++ b/src/marker.zig
@@ -1,0 +1,3 @@
+pub const Bytes = struct {
+    __proconio_marker_bytes: void,
+};


### PR DESCRIPTION
This PR adds support for inputs like:

```zig
// ...
var io = try proconio.init(allocator);
defer io.deinit();

const in = try io.input(struct {
    s: proconio.marker.Bytes,
});
std.debug.print("{s}\n", .{in.s});
```

However, the marker API could be reconsidered.

The current implementation follows the original proconio, where the type of `in.s` in this sample code is `[]const u8`, and `@TypeOf(in.s)` indeed returns `[]const u8`.
However, editor information via ZLS displays it as `proconio.marker.Bytes`, causing a type mismatch.
(Perhaps ZLS has limitations on `comptime` calculations that can be executed, though I haven't investigated this.)
Therefore, we could add a `value` field to the `Bytes` implementation to return an actual `proconio.marker.Bytes`.
This would allow access via `in.s.value` or by defining a getter like `in.s.value()`.

While basing decisions on the behavior of the evolving ZLS might be insufficient, there are other advantages.
For example, if we wanted to create a type for valid UTF-8 characters similar to Rust's `char` type in the future, the API might look like:

```zig
pub const Char = struct {
    __proconio_marker_char: void = {},
    value: u21,

    const Self = @This();

    pub fn fromBytes(bytes: []const u8) !Self {
        return .{ .value = try std.unicode.utf8Decode(bytes) };
    }

    // ...
};
```

In this case, having `proconio.marker.Char` returned rather than directly returning `u21` would be more convenient, allowing the `char` type to be used independently and providing access to various methods.
Of course, whether the `char` type example falls within proconio's responsibilities, or whether it's appropriate for a standalone `char` type to belong to the `marker` namespace, is a separate discussion.

This relates to questions of:

1. Whether to make the library comprehensive or keep it with minimal APIs
2. Whether to strictly adhere to the original proconio or implement proconio-zig specific extensions

I welcome your opinions on which API approach would be more appropriate.
